### PR TITLE
Browser: auto-detect and build vx6 binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 /vx6
 /chat
 internal/ebpf/onion_relay.o
-
+cmd/vx6/vx6
 .codex
 .codex/
 data/

--- a/Threat_Model/threat_model.md
+++ b/Threat_Model/threat_model.md
@@ -1,0 +1,30 @@
+# Threat Model (Current)
+
+VX6 provides secure service connectivity and discovery between peers, but its threat model is still evolving and not yet formally defined.
+
+## Assumptions
+
+- The network may contain untrusted or malicious nodes
+- Local registry data may be incomplete or stale
+- DHT participants may behave adversarially
+- Network observers may measure timing and traffic patterns
+
+## Protections
+
+- Each node has a cryptographic identity (Ed25519); only the holder of the private key can produce valid signatures for that identity
+- Node and service records are signed and verifiable, preventing impersonation
+- Peer-to-peer sessions are encrypted, protecting against passive eavesdropping
+- Hidden services use blinded lookup keys and encrypted descriptors to avoid direct exposure of endpoints
+- Service access does not require exposing public ports
+
+## Known Limitations
+
+- The DHT does not yet provide strong anti-Sybil protection, allowing attackers to introduce many fake nodes and influence service discovery and lookup routing
+- Malicious DHT participants may return incorrect or biased results, or drop/slow responses
+- Lookup timing and access patterns may be observable, enabling traffic analysis
+- Hidden-service anonymity is not equivalent to Tor-level guarantees
+- Local registry data is a cached view of the network and may be incomplete or outdated, which can affect service discovery until refreshed via the DHT
+- Relay path stability and seamless mid-stream failover are still evolving; connections may drop if relays fail
+- eBPF/XDP acceleration is experimental and not part of the active relay data path
+- No formal or externally reviewed threat model has been completed yet
+

--- a/browser/qt/src/browserwindow.cpp
+++ b/browser/qt/src/browserwindow.cpp
@@ -226,6 +226,7 @@ BrowserWindow::BrowserWindow(const QString &vx6Binary,
       m_profile(new QWebEngineProfile("vx6-browser", this)),
       m_tabs(nullptr), m_address(nullptr),
       m_controlDock(nullptr), m_ipv6Field(nullptr), m_nodeNameField(nullptr), m_nodeIdField(nullptr),
+      m_initNodeNameField(nullptr), m_connectServiceField(nullptr),
       m_renameField(nullptr), m_lookupField(nullptr), m_hostNameField(nullptr), m_hostPortField(nullptr), m_lookupResult(nullptr),
       m_logView(nullptr), m_logDock(nullptr), m_shortcuts(nullptr)
 {
@@ -249,6 +250,16 @@ BrowserWindow::BrowserWindow(const QString &vx6Binary,
     buildDock();
     registerBrowserCallbacks();
     maybeShowPermissionPrompt();
+    
+    // Ensure vx6 binary exists (build if needed)
+    appendLog("Initializing VX6...");
+    appendLog(m_backend->ensureVx6Binary());
+    
+    // Auto-start the node on browser launch
+    if (!m_backend->nodeRunning()) {
+        appendLog(m_backend->startNode());
+    }
+    
     openHome();
 }
 
@@ -499,6 +510,32 @@ void BrowserWindow::buildControlDock()
     netLay->addWidget(refreshPanel);
     outer->addWidget(netFrame);
 
+    auto [initFrame, initLay] = makeFrame("INITIALIZE NODE");
+    m_initNodeNameField = new QLineEdit(initFrame);
+    m_initNodeNameField->setPlaceholderText("New node name");
+    m_initNodeNameField->setStyleSheet(m_ipv6Field->styleSheet());
+    initLay->addWidget(m_initNodeNameField);
+    auto *initBtn = makeSideBtn("Init New Node", initFrame);
+    auto *initHint = new QLabel("Creates a new node with fresh keys. This will stop the current node.", initFrame);
+    initHint->setWordWrap(true);
+    initHint->setStyleSheet("QLabel { color: #7f889b; font-size: 11px; }");
+    initLay->addWidget(initBtn);
+    initLay->addWidget(initHint);
+    outer->addWidget(initFrame);
+
+    auto [connectFrame, connectLay] = makeFrame("CONNECT");
+    m_connectServiceField = new QLineEdit(connectFrame);
+    m_connectServiceField->setPlaceholderText("Service name or address");
+    m_connectServiceField->setStyleSheet(m_ipv6Field->styleSheet());
+    connectLay->addWidget(m_connectServiceField);
+    auto *connectBtn = makeSideBtn("Connect", connectFrame);
+    auto *connectHint = new QLabel("Connect to a VX6 service by name or address.", connectFrame);
+    connectHint->setWordWrap(true);
+    connectHint->setStyleSheet("QLabel { color: #7f889b; font-size: 11px; }");
+    connectLay->addWidget(connectBtn);
+    connectLay->addWidget(connectHint);
+    outer->addWidget(connectFrame);
+
     auto [renameFrame, renameLay] = makeFrame("NODE NAME");
     m_renameField = new QLineEdit(renameFrame);
     m_renameField->setPlaceholderText("Enter a new node name");
@@ -578,6 +615,8 @@ void BrowserWindow::buildControlDock()
 
     connect(copyIpv6, &QPushButton::clicked, this, &BrowserWindow::copyCurrentIpv6);
     connect(refreshPanel, &QPushButton::clicked, this, &BrowserWindow::refreshControlPanel);
+    connect(initBtn, &QPushButton::clicked, this, &BrowserWindow::initializeNodeFromPanel);
+    connect(connectBtn, &QPushButton::clicked, this, &BrowserWindow::connectServiceFromPanel);
     connect(renameBtn, &QPushButton::clicked, this, &BrowserWindow::renameNodeFromPanel);
     connect(serviceBtn, &QPushButton::clicked, this, &BrowserWindow::lookupServiceFromPanel);
     connect(nodeBtn, &QPushButton::clicked, this, &BrowserWindow::lookupNodeFromPanel);
@@ -587,6 +626,8 @@ void BrowserWindow::buildControlDock()
     connect(m_lookupField, &QLineEdit::returnPressed, this, &BrowserWindow::lookupServiceFromPanel);
     connect(m_renameField, &QLineEdit::returnPressed, this, &BrowserWindow::renameNodeFromPanel);
     connect(m_hostNameField, &QLineEdit::returnPressed, this, &BrowserWindow::hostServiceFromPanel);
+    connect(m_initNodeNameField, &QLineEdit::returnPressed, this, &BrowserWindow::initializeNodeFromPanel);
+    connect(m_connectServiceField, &QLineEdit::returnPressed, this, &BrowserWindow::connectServiceFromPanel);
     connect(m_controlDock, &QDockWidget::visibilityChanged, this, [this](bool visible)
             {
                 if (visible)
@@ -890,6 +931,40 @@ void BrowserWindow::stopHostedServiceFromPanel()
     refreshControlPanel();
     refreshStatus();
     navigateTo("vx6://services", false);
+}
+
+void BrowserWindow::initializeNodeFromPanel()
+{
+    if (!m_initNodeNameField) {
+        return;
+    }
+    const QString name = m_initNodeNameField->text().trimmed();
+    if (name.isEmpty()) {
+        appendLog("node init skipped: empty node name");
+        return;
+    }
+    appendLog(QString("initializing new node as %1…").arg(name));
+    const QString result = m_backend->initializeNode(name);
+    appendLog(result.trimmed());
+    m_initNodeNameField->clear();
+    refreshControlPanel();
+    refreshStatus();
+}
+
+void BrowserWindow::connectServiceFromPanel()
+{
+    if (!m_connectServiceField) {
+        return;
+    }
+    const QString target = m_connectServiceField->text().trimmed();
+    if (target.isEmpty()) {
+        appendLog("connect skipped: empty service name or address");
+        return;
+    }
+    appendLog(QString("connecting to %1…").arg(target));
+    const QString result = m_backend->connectService(target);
+    appendLog(result.trimmed());
+    m_connectServiceField->clear();
 }
 
 // backend callbacks

--- a/browser/qt/src/browserwindow.h
+++ b/browser/qt/src/browserwindow.h
@@ -38,6 +38,8 @@ private slots:
     void lookupHiddenFromPanel();
     void hostServiceFromPanel();
     void stopHostedServiceFromPanel();
+    void initializeNodeFromPanel();
+    void connectServiceFromPanel();
     void reloadNode();
     void startNode();
     void stopNode();
@@ -65,6 +67,8 @@ private:
     QLineEdit *m_ipv6Field;
     QLineEdit *m_nodeNameField;
     QLineEdit *m_nodeIdField;
+    QLineEdit *m_initNodeNameField;
+    QLineEdit *m_connectServiceField;
     QLineEdit *m_renameField;
     QLineEdit *m_lookupField;
     QLineEdit *m_hostNameField;

--- a/browser/qt/src/vx6backend.cpp
+++ b/browser/qt/src/vx6backend.cpp
@@ -1,12 +1,16 @@
 #include "vx6backend.h"
 
-#include <QCoreApplication>
+#include <QApplication>
 #include <QDir>
+#include <QEventLoop>
 #include <QFileInfo>
 #include <QProcess>
 #include <QProcessEnvironment>
 #include <QStandardPaths>
 #include <QStringList>
+
+#include <chrono>
+#include <thread>
 
 VX6Backend::VX6Backend(QString vx6Binary, QString configPath, QObject *parent)
     : QObject(parent), m_vx6Binary(std::move(vx6Binary)), m_configPath(std::move(configPath))
@@ -90,6 +94,95 @@ QString VX6Backend::resolveConfigPath() const
     return QStringLiteral("config.json");
 }
 
+bool VX6Backend::vx6BinaryExists() const
+{
+    const QString binPath = resolveBinaryPath();
+    return QFileInfo::exists(binPath) && QFileInfo(binPath).isExecutable();
+}
+
+bool VX6Backend::waitForProcessFinished(QProcess &proc, int msecs) const
+{
+    const auto start = std::chrono::steady_clock::now();
+    const auto timeout = std::chrono::milliseconds(msecs);
+    
+    while (proc.state() == QProcess::Running) {
+        const auto elapsed = std::chrono::steady_clock::now() - start;
+        if (elapsed > timeout) {
+            return false;  // Timeout
+        }
+        
+        // Process UI events to keep interface responsive
+        QApplication::processEvents(QEventLoop::AllEvents, 100);
+        
+        // Small sleep to avoid busy waiting
+        std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    }
+    
+    return true;  // Process finished normally
+}
+
+QString VX6Backend::ensureVx6Binary()
+{
+    if (vx6BinaryExists()) {
+        emit logLine(QStringLiteral("vx6 binary already available"));
+        return QStringLiteral("vx6 binary already available");
+    }
+
+    emit logLine(QStringLiteral("vx6 binary not found, building from source..."));
+
+    const QString appDir = QCoreApplication::applicationDirPath();
+    QDir dir(appDir);
+    dir.cdUp();  // qt/build -> qt
+    dir.cdUp();  // qt -> browser
+    dir.cdUp();  // browser -> project root
+    const QString projectRoot = dir.path();
+    
+    const QString buildCmd = QStringLiteral("go build -o %1 ./cmd/vx6")
+        .arg(QDir(appDir).filePath("vx6"));
+
+    QProcess buildProc;
+    buildProc.setWorkingDirectory(projectRoot);
+    buildProc.setProgram(QStringLiteral("sh"));
+    buildProc.setArguments({QStringLiteral("-c"), buildCmd});
+
+    emit logLine(QStringLiteral("building vx6 in: %1").arg(projectRoot));
+    buildProc.start();
+
+    if (!buildProc.waitForStarted(5000)) {
+        const QString msg = QStringLiteral("failed to start build process");
+        emit logLine(msg);
+        return msg;
+    }
+
+    if (!buildProc.waitForFinished(300000)) {  // 5 minute timeout
+        buildProc.kill();
+        buildProc.waitForFinished(2000);
+        const QString msg = QStringLiteral("vx6 build timed out");
+        emit logLine(msg);
+        return msg;
+    }
+
+    const QString buildOutput = QString::fromUtf8(buildProc.readAllStandardOutput());
+    const QString buildError = QString::fromUtf8(buildProc.readAllStandardError());
+    const bool buildSuccess = buildProc.exitStatus() == QProcess::NormalExit && buildProc.exitCode() == 0;
+
+    if (!buildError.trimmed().isEmpty()) {
+        emit logLine(buildError);
+    }
+    if (!buildOutput.trimmed().isEmpty()) {
+        emit logLine(buildOutput);
+    }
+
+    if (buildSuccess && vx6BinaryExists()) {
+        emit logLine(QStringLiteral("vx6 binary built successfully"));
+        return QStringLiteral("vx6 binary built successfully");
+    }
+
+    const QString msg = QStringLiteral("failed to build vx6 binary (exit code %1)").arg(buildProc.exitCode());
+    emit logLine(msg);
+    return msg;
+}
+
 QString VX6Backend::runVX6(const QStringList &args, bool *ok) const
 {
     QProcess proc;
@@ -111,7 +204,9 @@ QString VX6Backend::runVX6(const QStringList &args, bool *ok) const
         emit logLine(msg);
         return msg;
     }
-    if (!proc.waitForFinished(120000)) {
+    
+    // Use responsive wait to keep UI responsive during long operations
+    if (!waitForProcessFinished(proc, 120000)) {
         proc.kill();
         proc.waitForFinished(2000);
         if (ok) {
@@ -494,6 +589,63 @@ QString VX6Backend::renameNode(const QString &name)
     if (ok) {
         const QString reloadOut = runVX6(QStringList{"reload"}, &ok);
         return output + QStringLiteral("\n") + reloadOut;
+    }
+    return output;
+}
+
+QString VX6Backend::initializeNode(const QString &name)
+{
+    const QString trimmed = name.trimmed();
+    if (trimmed.isEmpty()) {
+        return QStringLiteral("node init failed: empty name");
+    }
+    bool ok = false;
+    
+    // Step 1: Stop the running node
+    if (nodeRunning()) {
+        emit logLine(QStringLiteral("stopping running node..."));
+        m_nodeProcess.terminate();
+        if (!m_nodeProcess.waitForFinished(3000)) {
+            m_nodeProcess.kill();
+            m_nodeProcess.waitForFinished(2000);
+        }
+        updateNodeState();
+        emit logLine(QStringLiteral("node stopped"));
+    }
+    
+    // Step 2: Run init
+    emit logLine(QStringLiteral("initializing new node with name: %1").arg(trimmed));
+    emit logLine(QStringLiteral("generating keys... this may take a moment"));
+    
+    const QString initOut = runVX6(
+        QStringList{"init", "--name", trimmed, "--listen", "[::]:4242"},
+        &ok);
+    
+    if (!ok) {
+        emit logLine(QStringLiteral("initialization failed"));
+        emit logLine(initOut);
+        return initOut;
+    }
+    
+    // Step 3: Start the new node
+    emit logLine(QStringLiteral("node initialized, starting new node..."));
+    const QString startResult = startNode();
+    emit logLine(startResult);
+    
+    return QStringLiteral("node reinitialized successfully");
+}
+
+QString VX6Backend::connectService(const QString &target)
+{
+    const QString trimmed = target.trimmed();
+    if (trimmed.isEmpty()) {
+        return QStringLiteral("connect failed: empty target");
+    }
+    bool ok = false;
+    emit logLine(QStringLiteral("connecting to: %1").arg(trimmed));
+    const QString output = runVX6(QStringList{"connect", "--service", trimmed, "--listen", "127.0.0.1:9999"}, &ok);
+    if (ok) {
+        return QStringLiteral("Connected to %1 on 127.0.0.1:9999\n%2").arg(trimmed, output);
     }
     return output;
 }

--- a/browser/qt/src/vx6backend.h
+++ b/browser/qt/src/vx6backend.h
@@ -35,6 +35,8 @@ public:
     QString startNode();
     QString stopNode();
     QString renameNode(const QString &name);
+    QString initializeNode(const QString &name);
+    QString connectService(const QString &target);
     QString hostService(const QString &serviceName, int port);
     QString stopHostedService(const QString &serviceName);
     QString lookupRaw(const QStringList &args, const QString &label) const;
@@ -42,6 +44,9 @@ public:
     QString runVX6(const QStringList &args, bool *ok = nullptr) const;
     QString resolveConfigPath() const;
     QString resolveBinaryPath() const;
+    
+    bool vx6BinaryExists() const;
+    QString ensureVx6Binary();
 
 signals:
     void logLine(const QString &line) const;
@@ -56,6 +61,8 @@ private:
     QString commandBlock(const QString &output) const;
     QString browserHintBlock() const;
     QString osNoticeBlock() const;
+    
+    bool waitForProcessFinished(QProcess &proc, int msecs) const;
 
     QString m_vx6Binary;
     QString m_configPath;


### PR DESCRIPTION
This PR improves the VX6 browser by removing the committed vx6 binary and adding automatic backend resolution.

Changes:
- Removed vx6 executable from the repository
- Added .gitignore rule to prevent committing binaries
- Implemented automatic detection of vx6 (local, PATH)
- Added fallback to build vx6 using `go build` if not found

Behavior:
- Fresh clone works without manual build if Go is available
- Existing vx6 installations are reused automatically

This reduces setup steps and improves developer experience.


Implementation:
- Added `ensureVx6Binary()` in backend
- Uses `QProcess` to invoke shell build command
- Sets working directory to project root
- Outputs logs for build success/failure
- Verifies binary existence after build



### 4. Command execution improvements

All VX6 CLI interactions are handled via:


## Behavior After This PR

### Fresh clone (no vx6, no PATH)
- Browser attempts to resolve binary → not found
- Triggers auto-build using Go
- Generated binary is placed in build directory
- Commands like `vx6 status` work immediately

### System with vx6 installed
- Existing vx6 binary is reused
- No build step triggered

### No Go installed
- Auto-build fails
- Browser returns clear error from build proces

## Testing

Tested with the following steps:

1. Removed vx6 binary from repository and local system
2. Verified:
  which vx6
  not existed
  still using browser it worked

3. Built only browser:
4. Ran browser:
Result:
- vx6 was automatically built using Go
- Browser successfully executed `vx6 status`
- Node initialization and control worked as expected