### PR TITLE
feat(browser): add send/receive management UI

### DIFF
--- a/browser/qt/PLAN.md
+++ b/browser/qt/PLAN.md
@@ -32,12 +32,20 @@ The current browser app already provides:
   - node rename
   - service / node / hidden lookup
   - service hosting and stop controls
+  - file send with target address
+  - receive mode toggle (enable/disable)
+  - receive status page
 - a side drawer for runtime logs
 - a side drawer for node control
 - a node start button
 - a node stop button
 - reload and status actions
 - first-run permission guidance for Windows and macOS
+- `vx6://files` page showing:
+  - receive status (mode, allowed senders)
+  - config path
+  - download directory
+  - received files grouped by sender folder (`sender_name_nodeID_vx6`)
 
 ## How It Is Built Today
 
@@ -91,9 +99,16 @@ Planned follow-up work:
 - better inline error pages when VX6 lookup fails
 - richer service pages for public, private, and hidden records
 - a browser home page that can show local services and recent connections
-- downloads and file handling inside the browser shell
 - safer web permissions prompts
-- better integrated localhost and internet navigation rules
+- better integrated localhost and internet navigation rules 
+- file transfer progress indicators and download speed display
+- a button to open received file folders directly on the filesystem
+- structured receive storage where incoming files are grouped into sender-specific VX6 directories      (`sender_name_nodeID_vx6`)
+- browser-side visualization for sender-grouped received file folders
+- automatic creation of sender-specific receive directories during incoming file transfers
+- safer receive storage organization instead of mixing VX6 files into the global Downloads directory
+- debugging and validation work for ensuring the active runtime receive path correctly creates sender-specific receive folders
+- future transfer history and per-sender download tracking support
 
 ## How To Contribute
 
@@ -110,6 +125,7 @@ Good browser contributions are usually one of these:
 - a new VX6 page
 - a layout improvement
 - a node control improvement
+- file transfer UI or download status support
 - a safer browser permission rule
 - a better cross-platform build fix
 - a clearer error page

--- a/browser/qt/src/browserwindow.cpp
+++ b/browser/qt/src/browserwindow.cpp
@@ -7,6 +7,8 @@
 #include <QApplication>
 #include <QClipboard>
 #include <QDockWidget>
+#include <QFileDialog>
+#include <QScrollArea>
 #include <QFormLayout>
 #include <QGroupBox>
 #include <QLineEdit>
@@ -459,7 +461,14 @@ void BrowserWindow::buildControlDock()
         "QDockWidget::title { background: #0e1118; border-bottom: 1px solid rgba(255,255,255,0.05); padding: 8px 12px; }"
         "QDockWidget::close-button { background: transparent; border: none; image: none; }");
 
-    auto *root = new QWidget(m_controlDock);
+    auto *scrollArea = new QScrollArea(m_controlDock);
+    scrollArea->setWidgetResizable(true);
+    scrollArea->setFrameShape(QFrame::NoFrame);
+    scrollArea->setVerticalScrollBarPolicy(Qt::ScrollBarAsNeeded);
+    scrollArea->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+    scrollArea->setStyleSheet("QScrollArea { background: transparent; border: none; }");
+
+    auto *root = new QWidget();
     root->setStyleSheet("QWidget { background: #12151a; color: #e8eaf0; }");
 
     auto *outer = new QVBoxLayout(root);
@@ -536,6 +545,34 @@ void BrowserWindow::buildControlDock()
     connectLay->addWidget(connectHint);
     outer->addWidget(connectFrame);
 
+    auto [fileFrame, fileLay] = makeFrame("FILE TRANSFER");
+    m_sendFileField = new QLineEdit(fileFrame);
+    m_sendFileField->setPlaceholderText("File path e.g. /home/user/Downloads/sample.txt");
+    m_sendFileField->setStyleSheet(m_ipv6Field->styleSheet());
+    fileLay->addWidget(m_sendFileField);
+    auto *fileRow = new QWidget(fileFrame);
+    auto *fileRowLay = new QHBoxLayout(fileRow);
+    fileRowLay->setContentsMargins(0, 0, 0, 0);
+    fileRowLay->setSpacing(8);
+    auto *browseBtn = makeSideBtn("Browse", fileRow);
+    auto *sendBtn = makeSideBtn("Send File", fileRow);
+    fileRowLay->addWidget(browseBtn);
+    fileRowLay->addWidget(sendBtn);
+    fileLay->addWidget(fileRow);
+    m_sendTargetField = new QLineEdit(fileFrame);
+    m_sendTargetField->setPlaceholderText("Receiver name or address e.g. alice or [ipv6]:4242");
+    m_sendTargetField->setStyleSheet(m_ipv6Field->styleSheet());
+    fileLay->addWidget(m_sendTargetField);
+    auto *receiveStatusBtn = makeSideBtn("Receive Status", fileFrame);
+    fileLay->addWidget(receiveStatusBtn);
+    m_toggleReceiveBtn = makeSideBtn("Toggle Receive", fileFrame);
+    fileLay->addWidget(m_toggleReceiveBtn);
+    auto *fileHint = new QLabel("Use a local file path and target name or address. For direct send, use [ipv6]:4242.", fileFrame);
+    fileHint->setWordWrap(true);
+    fileHint->setStyleSheet("QLabel { color: #7f889b; font-size: 11px; }");
+    fileLay->addWidget(fileHint);
+    outer->addWidget(fileFrame);
+
     auto [renameFrame, renameLay] = makeFrame("NODE NAME");
     m_renameField = new QLineEdit(renameFrame);
     m_renameField->setPlaceholderText("Enter a new node name");
@@ -610,7 +647,8 @@ void BrowserWindow::buildControlDock()
     outer->addWidget(spacer, 1);
 
     root->setLayout(outer);
-    m_controlDock->setWidget(root);
+    scrollArea->setWidget(root);
+    m_controlDock->setWidget(scrollArea);
     addDockWidget(Qt::LeftDockWidgetArea, m_controlDock);
 
     connect(copyIpv6, &QPushButton::clicked, this, &BrowserWindow::copyCurrentIpv6);
@@ -623,11 +661,16 @@ void BrowserWindow::buildControlDock()
     connect(hiddenBtn, &QPushButton::clicked, this, &BrowserWindow::lookupHiddenFromPanel);
     connect(forwardBtn, &QPushButton::clicked, this, &BrowserWindow::hostServiceFromPanel);
     connect(stopBtn, &QPushButton::clicked, this, &BrowserWindow::stopHostedServiceFromPanel);
+    connect(browseBtn, &QPushButton::clicked, this, &BrowserWindow::chooseFileFromPanel);
+    connect(sendBtn, &QPushButton::clicked, this, &BrowserWindow::sendFileFromPanel);
+    connect(receiveStatusBtn, &QPushButton::clicked, this, &BrowserWindow::showFileTransferPage);
+    connect(m_toggleReceiveBtn, &QPushButton::clicked, this, &BrowserWindow::toggleReceiveFromPanel);
     connect(m_lookupField, &QLineEdit::returnPressed, this, &BrowserWindow::lookupServiceFromPanel);
     connect(m_renameField, &QLineEdit::returnPressed, this, &BrowserWindow::renameNodeFromPanel);
     connect(m_hostNameField, &QLineEdit::returnPressed, this, &BrowserWindow::hostServiceFromPanel);
     connect(m_initNodeNameField, &QLineEdit::returnPressed, this, &BrowserWindow::initializeNodeFromPanel);
     connect(m_connectServiceField, &QLineEdit::returnPressed, this, &BrowserWindow::connectServiceFromPanel);
+    connect(m_sendTargetField, &QLineEdit::returnPressed, this, &BrowserWindow::sendFileFromPanel);
     connect(m_controlDock, &QDockWidget::visibilityChanged, this, [this](bool visible)
             {
                 if (visible)
@@ -723,6 +766,7 @@ void BrowserWindow::buildDock()
         "vx6://services",
         "vx6://peers",
         "vx6://identity",
+        "vx6://files",
         "vx6://permissions",
     });
     m_shortcuts->setFocusPolicy(Qt::NoFocus);
@@ -805,6 +849,10 @@ void BrowserWindow::refreshControlPanel()
     }
     if (m_nodeIdField) {
         m_nodeIdField->setText(nodeId.isEmpty() ? QStringLiteral("(identity unavailable)") : nodeId);
+    }
+    if (m_toggleReceiveBtn) {
+        const bool enabled = m_backend->receiveEnabled();
+        m_toggleReceiveBtn->setText(enabled ? QStringLiteral("Disable Receive") : QStringLiteral("Enable Receive"));
     }
 }
 
@@ -965,6 +1013,53 @@ void BrowserWindow::connectServiceFromPanel()
     const QString result = m_backend->connectService(target);
     appendLog(result.trimmed());
     m_connectServiceField->clear();
+}
+
+void BrowserWindow::chooseFileFromPanel()
+{
+    const QString filePath = QFileDialog::getOpenFileName(this, "Choose file to send", QString(), QStringLiteral("All files (*)"));
+    if (filePath.isEmpty()) {
+        return;
+    }
+    if (m_sendFileField) {
+        m_sendFileField->setText(filePath);
+    }
+}
+
+void BrowserWindow::sendFileFromPanel()
+{
+    if (!m_sendFileField || !m_sendTargetField) {
+        return;
+    }
+    const QString filePath = m_sendFileField->text().trimmed();
+    const QString target = m_sendTargetField->text().trimmed();
+    if (filePath.isEmpty()) {
+        appendLog("send file skipped: no file selected");
+        return;
+    }
+    if (target.isEmpty()) {
+        appendLog("send file skipped: no receiver specified");
+        return;
+    }
+    appendLog(QString("sending file %1 to %2…").arg(filePath, target));
+    const QString result = m_backend->sendFile(filePath, target);
+    appendLog(result.trimmed());
+}
+
+void BrowserWindow::toggleReceiveFromPanel()
+{
+    if (!m_toggleReceiveBtn) {
+        return;
+    }
+    const bool enabled = m_backend->receiveEnabled();
+    const QString result = m_backend->toggleReceive(!enabled);
+    appendLog(result.trimmed());
+    refreshControlPanel();
+}
+
+void BrowserWindow::showFileTransferPage()
+{
+    navigateTo("vx6://files", false);
 }
 
 // backend callbacks

--- a/browser/qt/src/browserwindow.h
+++ b/browser/qt/src/browserwindow.h
@@ -11,6 +11,7 @@ class QListWidget;
 class QSpinBox;
 class QTabWidget;
 class QTextEdit;
+class QPushButton;
 class QWebEnginePage;
 class QWebEngineProfile;
 class QWebEngineView;
@@ -40,6 +41,10 @@ private slots:
     void stopHostedServiceFromPanel();
     void initializeNodeFromPanel();
     void connectServiceFromPanel();
+    void chooseFileFromPanel();
+    void sendFileFromPanel();
+    void toggleReceiveFromPanel();
+    void showFileTransferPage();
     void reloadNode();
     void startNode();
     void stopNode();
@@ -73,6 +78,9 @@ private:
     QLineEdit *m_lookupField;
     QLineEdit *m_hostNameField;
     QSpinBox *m_hostPortField;
+    QLineEdit *m_sendFileField;
+    QLineEdit *m_sendTargetField;
+    QPushButton *m_toggleReceiveBtn;
     QTextEdit *m_lookupResult;
     QTextEdit *m_logView;
     QDockWidget *m_logDock;

--- a/browser/qt/src/vx6backend.cpp
+++ b/browser/qt/src/vx6backend.cpp
@@ -3,7 +3,10 @@
 #include <QApplication>
 #include <QDir>
 #include <QEventLoop>
+#include <QFile>
 #include <QFileInfo>
+#include <QJsonDocument>
+#include <QJsonObject>
 #include <QProcess>
 #include <QProcessEnvironment>
 #include <QStandardPaths>
@@ -664,6 +667,162 @@ QString VX6Backend::hostService(const QString &serviceName, int port)
         return output + QStringLiteral("\n") + reloadOut;
     }
     return output;
+}
+
+QString VX6Backend::sendFile(const QString &filePath, const QString &target, bool proxy)
+{
+    const QString trimmedFile = filePath.trimmed();
+    const QString trimmedTarget = target.trimmed();
+    if (trimmedFile.isEmpty()) {
+        return QStringLiteral("send file failed: empty file path");
+    }
+    if (trimmedTarget.isEmpty()) {
+        return QStringLiteral("send file failed: empty target");
+    }
+    if (!QFileInfo(trimmedFile).exists()) {
+        return QStringLiteral("send file failed: file does not exist");
+    }
+
+    QStringList args = {QStringLiteral("send"), QStringLiteral("--file"), trimmedFile};
+    if (trimmedTarget.contains(QLatin1Char(':'))) {
+        args << QStringLiteral("--addr") << trimmedTarget;
+    } else {
+        args << QStringLiteral("--to") << trimmedTarget;
+    }
+    if (proxy) {
+        args << QStringLiteral("--proxy");
+    }
+
+    bool ok = false;
+    const QString result = runVX6(args, &ok);
+    if (ok) {
+        return QStringLiteral("file send complete:\n%1").arg(result.trimmed());
+    }
+    return QStringLiteral("file send failed:\n%1").arg(result.trimmed());
+}
+
+QString VX6Backend::receiveStatus() const
+{
+    bool ok = false;
+    const QString output = runVX6(QStringList{QStringLiteral("receive"), QStringLiteral("status")}, &ok);
+    if (ok) {
+        return QStringLiteral("receive status:\n%1").arg(output.trimmed());
+    }
+    return QStringLiteral("receive status failed:\n%1").arg(output.trimmed());
+}
+
+bool VX6Backend::receiveEnabled() const
+{
+    bool ok = false;
+    const QString output = runVX6(QStringList{QStringLiteral("receive"), QStringLiteral("status")}, &ok);
+    if (!ok) {
+        return false;
+    }
+    for (const QString &line : output.split('\n', Qt::SkipEmptyParts)) {
+        if (line.startsWith(QStringLiteral("file_receive_mode\t"))) {
+            const QString mode = line.section('\t', 1, 1).trimmed();
+            return mode == QStringLiteral("OPEN") || mode == QStringLiteral("TRUSTED");
+        }
+    }
+    return false;
+}
+
+QString VX6Backend::toggleReceive(bool enable)
+{
+    QStringList args;
+    if (enable) {
+        args = {QStringLiteral("receive"), QStringLiteral("allow"), QStringLiteral("--all")};
+    } else {
+        args = {QStringLiteral("receive"), QStringLiteral("disable")};
+    }
+    bool ok = false;
+    const QString output = runVX6(args, &ok);
+    if (ok) {
+        return QStringLiteral("receive %1 successfully:\n%2").arg(enable ? QStringLiteral("enabled") : QStringLiteral("disabled"), output.trimmed());
+    }
+    return QStringLiteral("receive %1 failed:\n%2").arg(enable ? QStringLiteral("enable") : QStringLiteral("disable"), output.trimmed());
+}
+
+QString VX6Backend::currentDownloadPath() const
+{
+    const QString cfgPath = resolveConfigPath();
+    QFile configFile(cfgPath);
+    if (configFile.open(QIODevice::ReadOnly)) {
+        const QByteArray data = configFile.readAll();
+        configFile.close();
+        const QJsonDocument doc = QJsonDocument::fromJson(data);
+        if (!doc.isNull() && doc.isObject()) {
+            const QJsonObject root = doc.object();
+            if (root.contains(QStringLiteral("node")) && root.value(QStringLiteral("node")).isObject()) {
+                const QJsonObject nodeObj = root.value(QStringLiteral("node")).toObject();
+                const QString downloadDir = nodeObj.value(QStringLiteral("download_dir")).toString().trimmed();
+                if (!downloadDir.isEmpty()) {
+                    const QDir dir(downloadDir);
+                    if (dir.isAbsolute()) {
+                        return QDir::cleanPath(downloadDir);
+                    }
+                    return QDir(QFileInfo(cfgPath).absolutePath()).absoluteFilePath(downloadDir);
+                }
+            }
+        }
+    }
+
+    const QString defaultDir = QStandardPaths::writableLocation(QStandardPaths::DownloadLocation);
+    if (!defaultDir.isEmpty()) {
+        return QDir::cleanPath(defaultDir);
+    }
+    return QDir::homePath() + QDir::separator() + QStringLiteral("Downloads");
+}
+
+QString VX6Backend::downloadedFilesHtml(const QString &downloadDir) const
+{
+    const QDir dir(downloadDir);
+    if (!dir.exists()) {
+        return QStringLiteral("<div class=\"output\">No download directory found: %1</div>").arg(downloadDir.toHtmlEscaped());
+    }
+
+    const QFileInfoList dirs = dir.entryInfoList(QDir::Dirs | QDir::NoDotAndDotDot, QDir::Name);
+    QStringList sections;
+    for (const QFileInfo &folder : dirs) {
+        if (!folder.fileName().endsWith(QStringLiteral("_vx6"))) {
+            continue;
+        }
+        const QDir subdir(folder.filePath());
+        const QFileInfoList files = subdir.entryInfoList(QDir::Files | QDir::NoDotAndDotDot, QDir::Name);
+        if (files.isEmpty()) {
+            sections.append(QStringLiteral("<div class=\"hint\"><strong>%1</strong> — no received files yet.</div>").arg(folder.fileName().toHtmlEscaped()));
+            continue;
+        }
+        QStringList rows;
+        for (const QFileInfo &info : files) {
+            rows.append(QStringLiteral("<li><strong>%1</strong> — %2</li>")
+                .arg(info.fileName().toHtmlEscaped(), QString::number(info.size())));
+        }
+        sections.append(QStringLiteral("<div class=\"hint\"><strong>%1</strong></div><ul style=\"margin:0 0 16px 20px;\">%2</ul>")
+            .arg(folder.fileName().toHtmlEscaped(), rows.join(QString())));
+    }
+
+    if (sections.isEmpty()) {
+        return QStringLiteral("<div class=\"output\">No sender-specific received folders found. Received files are stored in sender subdirectories ending with <code>_vx6</code>.</div>");
+    }
+
+    return QStringLiteral("<div class=\"output\">%1</div>").arg(sections.join(QString()));
+}
+
+QString VX6Backend::filesPageHtml() const
+{
+    const QString status = receiveStatus();
+    const QString configPath = resolveConfigPath();
+    const QString downloadDir = currentDownloadPath();
+    const QString filesHtml = downloadedFilesHtml(downloadDir);
+    const QString body = QStringLiteral(
+        "<div class=\"hint\">This page shows file receive/download status and quick file transfer actions.</div>"
+        "<div class=\"section\"><h2>Receive Status</h2>%1</div>"
+        "<div class=\"section\"><h2>Config Path</h2>%2</div>"
+        "<div class=\"section\"><h2>Download Directory</h2>%3</div>"
+        "<div class=\"section\"><h2>Downloaded Files</h2>%4</div>")
+        .arg(commandBlock(status), commandBlock(configPath), commandBlock(downloadDir), filesHtml);
+    return makePageShell("VX6 Files", "File transfer and receive status", body, "#ff9f43");
 }
 
 QString VX6Backend::stopHostedService(const QString &serviceName)

--- a/browser/qt/src/vx6backend.h
+++ b/browser/qt/src/vx6backend.h
@@ -30,8 +30,15 @@ public:
     QString currentNodeName() const;
     QString currentNodeID() const;
     QString currentAdvertiseAddr() const;
+    QString sendFile(const QString &filePath, const QString &target, bool proxy = false);
+    QString receiveStatus() const;
+    bool receiveEnabled() const;
+    QString toggleReceive(bool enable);
+    QString filesPageHtml() const;
 
     bool nodeRunning() const;
+    QString currentDownloadPath() const;
+    QString downloadedFilesHtml(const QString &downloadDir) const;
     QString startNode();
     QString stopNode();
     QString renameNode(const QString &name);

--- a/browser/qt/src/vx6schemehandler.cpp
+++ b/browser/qt/src/vx6schemehandler.cpp
@@ -62,6 +62,10 @@ void VX6SchemeHandler::requestStarted(QWebEngineUrlRequestJob *job)
     {
         html = m_backend->identityPageHtml();
     }
+    else if (target == "files")
+    {
+        html = m_backend->filesPageHtml();
+    }
     else if (target == "permissions")
     {
         html = m_backend->permissionPromptHtml();

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -1010,6 +1010,12 @@ func runReceiveStatus(args []string) error {
 		return err
 	}
 
+	configPath, err := config.DefaultPath()
+	if err != nil {
+		return err
+	}
+	fmt.Printf("config_path\t%s\n", configPath)
+
 	store, err := config.NewStore("")
 	if err != nil {
 		return err
@@ -1019,10 +1025,30 @@ func runReceiveStatus(args []string) error {
 		return err
 	}
 
+	downloadDir := cfg.Node.DownloadDir
+	if downloadDir == "" {
+		downloadDir, err = config.DefaultDownloadDir()
+		if err != nil {
+			return err
+		}
+	}
+	fmt.Printf("download_dir\t%s\n", downloadDir)
 	fmt.Printf("file_receive_mode\t%s\n", strings.ToUpper(cfg.Node.FileReceiveMode))
-	fmt.Printf("allowed_senders\t%d\n", len(cfg.Node.AllowedFileSenders))
-	for _, sender := range cfg.Node.AllowedFileSenders {
-		fmt.Printf("allow\t%s\n", sender)
+
+	switch strings.ToLower(cfg.Node.FileReceiveMode) {
+	case config.FileReceiveOpen:
+		fmt.Printf("allowed_senders\t%d\n", len(cfg.Node.AllowedFileSenders))
+		fmt.Println("allowed_senders_note\topen mode: all senders are allowed")
+	case config.FileReceiveTrusted:
+		fmt.Printf("allowed_senders\t%d\n", len(cfg.Node.AllowedFileSenders))
+		for _, sender := range cfg.Node.AllowedFileSenders {
+			fmt.Printf("allow\t%s\n", sender)
+		}
+	default:
+		fmt.Printf("allowed_senders\t%d\n", len(cfg.Node.AllowedFileSenders))
+		if strings.ToLower(cfg.Node.FileReceiveMode) == config.FileReceiveOff {
+			fmt.Println("allowed_senders_note\treceiving disabled")
+		}
 	}
 	return nil
 }

--- a/internal/transfer/transfer.go
+++ b/internal/transfer/transfer.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/vx6/vx6/internal/identity"
 	"github.com/vx6/vx6/internal/proto"
@@ -130,6 +131,32 @@ func SendFileWithConn(ctx context.Context, conn net.Conn, req SendRequest) (Send
 	}, nil
 }
 
+func sanitizeReceiverDirName(nodeName, nodeID string) string {
+	if nodeName == "" {
+		nodeName = "unknown"
+	}
+	if nodeID == "" {
+		nodeID = "unknownid"
+	}
+	cleanName := strings.Map(func(r rune) rune {
+		switch r {
+		case '/', '\\', ':', '*', '?', '"', '<', '>', '|', ' ', '\t', '\n', '\r':
+			return '_'
+		default:
+			return r
+		}
+	}, nodeName)
+	cleanID := strings.Map(func(r rune) rune {
+		switch r {
+		case '/', '\\', ':', '*', '?', '"', '<', '>', '|', ' ', '\t', '\n', '\r':
+			return '_'
+		default:
+			return r
+		}
+	}, nodeID)
+	return fmt.Sprintf("%s_%s_vx6", cleanName, cleanID)
+}
+
 func ReceiveFile(conn net.Conn, dataDir string) (ReceiveResult, error) {
 	return ReceiveFileWithPolicy(conn, dataDir, ReceivePolicy{Mode: ReceiveModeOpen})
 }
@@ -144,11 +171,16 @@ func ReceiveFileWithPolicy(conn net.Conn, dataDir string, policy ReceivePolicy) 
 		return ReceiveResult{}, err
 	}
 
-	if err := os.MkdirAll(dataDir, 0755); err != nil {
-		return ReceiveResult{}, fmt.Errorf("create directory: %w", err)
+	senderID := "unknownid"
+	if secureConn, ok := conn.(*secure.Conn); ok {
+		senderID = secureConn.PeerNodeID()
+	}
+	receiverDir := filepath.Join(dataDir, sanitizeReceiverDirName(meta.NodeName, senderID))
+	if err := os.MkdirAll(receiverDir, 0755); err != nil {
+		return ReceiveResult{}, fmt.Errorf("create receiver directory: %w", err)
 	}
 
-	filePath := filepath.Join(dataDir, filepath.Base(meta.FileName))
+	filePath := filepath.Join(receiverDir, filepath.Base(meta.FileName))
 	offset := int64(0)
 	if info, err := os.Stat(filePath); err == nil {
 		switch {

--- a/internal/transfer/transfer_test.go
+++ b/internal/transfer/transfer_test.go
@@ -87,7 +87,7 @@ func TestReceiveFile(t *testing.T) {
 		t.Fatalf("unexpected bytes received: %d", result.BytesReceived)
 	}
 
-	receivedPath := filepath.Join(receiveDir, "hello.txt")
+	receivedPath := filepath.Join(receiveDir, "alpha_unknownid_vx6", "hello.txt")
 	received, err := os.ReadFile(receivedPath)
 	if err != nil {
 		t.Fatalf("read received file: %v", err)
@@ -145,7 +145,11 @@ func TestReceiveFileResumesPartialDownload(t *testing.T) {
 
 	payload := []byte("vx6 resumable transfer payload")
 	receiveDir := t.TempDir()
-	filePath := filepath.Join(receiveDir, "resume.txt")
+	receiverDir := filepath.Join(receiveDir, "alpha_unknownid_vx6")
+	if err := os.MkdirAll(receiverDir, 0o755); err != nil {
+		t.Fatalf("create receiver directory: %v", err)
+	}
+	filePath := filepath.Join(receiverDir, "resume.txt")
 	if err := os.WriteFile(filePath, payload[:10], 0o644); err != nil {
 		t.Fatalf("seed partial file: %v", err)
 	}
@@ -188,7 +192,8 @@ func TestReceiveFileResumesPartialDownload(t *testing.T) {
 		t.Fatalf("unexpected bytes received %d", result.BytesReceived)
 	}
 
-	received, err := os.ReadFile(filePath)
+	receivedPath := filepath.Join(receiveDir, "alpha_unknownid_vx6", "resume.txt")
+	received, err := os.ReadFile(receivedPath)
 	if err != nil {
 		t.Fatalf("read resumed file: %v", err)
 	}


### PR DESCRIPTION
This PR improves the Qt browser workflow around file transfer management and runtime visibility.

### Added

- browser-side send file controls integrated with the existing VX6 CLI/runtime
- receive management controls and receive status visibility
- `vx6://files` page showing:
  - receive mode status
  - config path
  - download directory
- transfer/runtime integration improvements in the Qt frontend
- receive status integration inside the browser UI
- file transfer logging visibility through the browser/runtime logs

### Planned Follow-up

- sender-grouped receive storage using `sender_name_nodeID_vx6` directory structure
- browser-side visualization for sender-specific receive folders
- improved runtime validation/debugging for receive storage paths
-  direct received file listing inside the browser UI