### PR TITLE
fix(node): add handshake timeout and connection limit to accept loop

### DIFF
--- a/apps/vx6comms/main.go
+++ b/apps/vx6comms/main.go
@@ -1684,6 +1684,35 @@ func parseDeviceNamesFromFFmpeg(kind string) []string {
 	return opts
 }
 
+func (s *state) runDeviceTest(cfg mediaConfig) (string, error) {
+	vConn, vPort, err := listenRTPPort()
+	if err != nil {
+		return "", fmt.Errorf("could not open video RTP port: %w", err)
+	}
+	defer vConn.Close()
+	aConn, aPort, err := listenRTPPort()
+	if err != nil {
+		return "", fmt.Errorf("could not open audio RTP port: %w", err)
+	}
+	defer aConn.Close()
+
+	cmd := buildFFmpegCaptureCommand(vPort, aPort, cfg)
+	if cmd == nil {
+		return "", fmt.Errorf("ffmpeg not found or unsupported platform")
+	}
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		snippet := string(output)
+		if len(snippet) > 512 {
+			snippet = snippet[:512] + "…"
+		}
+		return "", fmt.Errorf("device test failed: %w\n%s", err, snippet)
+	}
+	report := fmt.Sprintf("Device test passed.\nVideo device: %s\nAudio device: %s\nResolution: %dx%d @ %d fps\nVideo bitrate: %d kbps\nAudio bitrate: %d kbps",
+		cfg.VideoDevice, cfg.AudioDevice, cfg.Width, cfg.Height, cfg.FPS, cfg.VideoBitrateKbps, cfg.AudioBitrateKbps)
+	return report, nil
+}
+
 func (s *state) showMediaPreview(path string, win fyne.Window) {
 	ext := strings.ToLower(filepath.Ext(path))
 	switch ext {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -39,6 +39,7 @@ type NodeConfig struct {
 	HideEndpoint         bool             `json:"hide_endpoint"`
 	RelayMode            string           `json:"relay_mode,omitempty"`
 	RelayResourcePercent int              `json:"relay_resource_percent,omitempty"`
+	MaxConcurrentConns   int              `json:"max_concurrent_conns,omitempty"`
 	DataDir              string           `json:"data_dir"`
 	DownloadDir          string           `json:"download_dir"`
 	KnownPeerAddrs       []string         `json:"known_peer_addrs,omitempty"`
@@ -352,6 +353,7 @@ func normalize(cfg *File) {
 		cfg.Node.RelayMode = RelayModeOn
 	}
 	cfg.Node.RelayResourcePercent = NormalizeRelayResourcePercent(cfg.Node.RelayResourcePercent)
+	cfg.Node.MaxConcurrentConns = NormalizeMaxConcurrentConns(cfg.Node.MaxConcurrentConns)
 	if cfg.Node.DataDir == "" || cfg.Node.DataDir == "./data/inbox" {
 		cfg.Node.DataDir = defaultDataDirValue()
 	}
@@ -601,6 +603,19 @@ func NormalizeRelayResourcePercent(percent int) int {
 		return 90
 	default:
 		return percent
+	}
+}
+
+func NormalizeMaxConcurrentConns(n int) int {
+	switch {
+	case n <= 0:
+		return 1024
+	case n < 64:
+		return 64
+	case n > 65535:
+		return 65535
+	default:
+		return n
 	}
 }
 

--- a/internal/node/accept_hardening_test.go
+++ b/internal/node/accept_hardening_test.go
@@ -1,0 +1,207 @@
+package node
+
+import (
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/vx6/vx6/internal/proto"
+)
+
+func testListener(t *testing.T) (net.Listener, string) {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	return ln, ln.Addr().String()
+}
+
+func acceptOne(ln net.Listener, deadline time.Duration) (byte, error) {
+	conn, err := ln.Accept()
+	if err != nil {
+		return 0, err
+	}
+	defer conn.Close()
+	if err := conn.SetReadDeadline(time.Now().Add(deadline)); err != nil {
+		return 0, err
+	}
+	kind, err := proto.ReadHeader(conn)
+	if err != nil {
+		return 0, err
+	}
+	_ = conn.SetReadDeadline(time.Time{})
+	return kind, nil
+}
+
+func TestStalledPeerDisconnected(t *testing.T) {
+	t.Parallel()
+
+	ln, addr := testListener(t)
+	defer ln.Close()
+
+	deadline := 500 * time.Millisecond
+
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := acceptOne(ln, deadline)
+		errCh <- err
+	}()
+
+	conn, err := net.Dial("tcp", addr)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+
+	select {
+	case err := <-errCh:
+		if err == nil {
+			t.Fatal("expected header read to fail for stalled peer, got nil")
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for stalled peer to be disconnected")
+	}
+}
+
+func TestPartialHeaderTimeout(t *testing.T) {
+	t.Parallel()
+
+	ln, addr := testListener(t)
+	defer ln.Close()
+
+	deadline := 500 * time.Millisecond
+
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := acceptOne(ln, deadline)
+		errCh <- err
+	}()
+
+	conn, err := net.Dial("tcp", addr)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+
+	_, _ = conn.Write([]byte{'V', 'X'})
+
+	select {
+	case err := <-errCh:
+		if err == nil {
+			t.Fatal("expected header read to fail for partial header, got nil")
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for partial header timeout")
+	}
+}
+
+func TestConnectionCapEnforced(t *testing.T) {
+	t.Parallel()
+
+	const cap = 3
+
+	ln, addr := testListener(t)
+	defer ln.Close()
+
+	sem := make(chan struct{}, cap)
+	var mu sync.Mutex
+	accepted := 0
+	dropped := 0
+	done := make(chan struct{})
+
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			select {
+			case sem <- struct{}{}:
+				mu.Lock()
+				accepted++
+				mu.Unlock()
+				go func(c net.Conn) {
+					<-done
+					c.Close()
+					<-sem
+				}(conn)
+			default:
+				mu.Lock()
+				dropped++
+				mu.Unlock()
+				conn.Close()
+			}
+		}
+	}()
+
+	conns := make([]net.Conn, 0, cap)
+	for i := 0; i < cap; i++ {
+		c, err := net.Dial("tcp", addr)
+		if err != nil {
+			t.Fatalf("dial %d: %v", i, err)
+		}
+		conns = append(conns, c)
+	}
+	time.Sleep(100 * time.Millisecond)
+
+	mu.Lock()
+	if accepted != cap {
+		t.Fatalf("expected %d accepted, got %d", cap, accepted)
+	}
+	mu.Unlock()
+
+	extra, err := net.Dial("tcp", addr)
+	if err != nil {
+		t.Fatalf("dial extra: %v", err)
+	}
+	extra.Close()
+	time.Sleep(100 * time.Millisecond)
+
+	mu.Lock()
+	if dropped != 1 {
+		t.Fatalf("expected 1 dropped, got %d", dropped)
+	}
+	mu.Unlock()
+
+	close(done)
+	time.Sleep(100 * time.Millisecond)
+
+	mu.Lock()
+	prevAccepted := accepted
+	mu.Unlock()
+
+	c, err := net.Dial("tcp", addr)
+	if err != nil {
+		t.Fatalf("dial after release: %v", err)
+	}
+	c.Close()
+	time.Sleep(100 * time.Millisecond)
+
+	mu.Lock()
+	if accepted <= prevAccepted {
+		t.Fatalf("expected a new connection to be accepted after slot release, accepted=%d prev=%d", accepted, prevAccepted)
+	}
+	mu.Unlock()
+}
+
+func TestEffectiveMaxConcurrentConns(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		input int
+		want  int
+	}{
+		{0, defaultMaxConcurrentConns},
+		{-1, defaultMaxConcurrentConns},
+		{512, 512},
+		{2048, 2048},
+	}
+	for _, tc := range tests {
+		got := effectiveMaxConcurrentConns(tc.input)
+		if got != tc.want {
+			t.Errorf("effectiveMaxConcurrentConns(%d) = %d, want %d", tc.input, got, tc.want)
+		}
+	}
+}

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -39,6 +39,7 @@ const (
 	syncMaxRounds       = 3
 	syncParallelTargets = 6
 	dhtRefreshLead      = 5 * time.Minute
+	maxConcurrentConns  = 1024
 )
 
 type ServiceRefresher func() map[string]string
@@ -206,6 +207,7 @@ func Run(ctx context.Context, log io.Writer, cfg Config) error {
 		<-ctx.Done()
 		_ = listener.Close()
 	}()
+	connSem := make(chan struct{}, maxConcurrentConns)
 
 	for {
 		conn, err := listener.Accept()
@@ -223,8 +225,16 @@ func Run(ctx context.Context, log io.Writer, cfg Config) error {
 			return fmt.Errorf("accept connection: %w", err)
 		}
 
+		select {
+		case connSem <- struct{}{}:
+		default:
+			_ = conn.Close()
+			continue
+		}
+
 		wg.Add(1)
 		go func() {
+			defer func() { <-connSem }()
 			defer wg.Done()
 			defer conn.Close()
 			done := make(chan struct{})
@@ -236,8 +246,14 @@ func Run(ctx context.Context, log io.Writer, cfg Config) error {
 				case <-done:
 				}
 			}()
+			//bug: after listener.Accept() the goroutine immediately calls proto.ReadHeader(reader) with no timeout
+			//a malicious peer can open thousands of tcp connections without sending data each holding a goroutine+file descriptor forever
 			reader := bufio.NewReader(conn)
+			//fix:add a read deadline immediately after the reader is created
+			conn.SetReadDeadline(time.Now().Add(10 * time.Second))
 			kind, err := proto.ReadHeader(reader)
+			//after successful read clear the deadline
+			conn.SetReadDeadline(time.Time{})
 			if err != nil {
 				if errors.Is(err, io.EOF) {
 					return

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -31,15 +31,22 @@ import (
 )
 
 const (
-	syncCycleInterval   = 10 * time.Second
-	syncWarmupInterval  = 2 * time.Second
-	syncWarmupRounds    = 4
-	syncTargetTimeout   = 2 * time.Second
-	syncProbeTimeout    = 1 * time.Second
-	syncMaxRounds       = 3
-	syncParallelTargets = 6
-	dhtRefreshLead      = 5 * time.Minute
-	maxConcurrentConns  = 1024
+	syncCycleInterval         = 10 * time.Second
+	syncWarmupInterval        = 2 * time.Second
+	syncWarmupRounds          = 4
+	syncTargetTimeout         = 2 * time.Second
+	syncProbeTimeout          = 1 * time.Second
+	syncMaxRounds             = 3
+	syncParallelTargets       = 6
+	dhtRefreshLead            = 5 * time.Minute
+	defaultMaxConcurrentConns = 1024
+	headerReadDeadline        = 10 * time.Second
+	handshakeDeadline         = 30 * time.Second
+	dhtPayloadDeadline        = 15 * time.Second
+	discoveryDeadline         = 30 * time.Second
+	relayHandshakeDeadline    = 60 * time.Second
+	serviceProxyDeadline      = 30 * time.Second
+	idleSessionDeadline       = 5 * time.Minute
 )
 
 type ServiceRefresher func() map[string]string
@@ -54,6 +61,7 @@ type Config struct {
 	HideEndpoint         bool
 	RelayMode            string
 	RelayResourcePercent int
+	MaxConcurrentConns   int
 	DataDir              string
 	ReceiveDir           string
 	FileReceiveMode      string
@@ -207,7 +215,9 @@ func Run(ctx context.Context, log io.Writer, cfg Config) error {
 		<-ctx.Done()
 		_ = listener.Close()
 	}()
-	connSem := make(chan struct{}, maxConcurrentConns)
+	connCap := effectiveMaxConcurrentConns(cfg.MaxConcurrentConns)
+	connSem := make(chan struct{}, connCap)
+	fmt.Fprintf(log, "connection cap: %d concurrent connections\n", connCap)
 
 	for {
 		conn, err := listener.Accept()
@@ -228,6 +238,7 @@ func Run(ctx context.Context, log io.Writer, cfg Config) error {
 		select {
 		case connSem <- struct{}{}:
 		default:
+			fmt.Fprintf(log, "connection cap saturated (%d/%d), dropping connection from %s\n", connCap, connCap, conn.RemoteAddr().String())
 			_ = conn.Close()
 			continue
 		}
@@ -246,14 +257,14 @@ func Run(ctx context.Context, log io.Writer, cfg Config) error {
 				case <-done:
 				}
 			}()
-			//bug: after listener.Accept() the goroutine immediately calls proto.ReadHeader(reader) with no timeout
-			//a malicious peer can open thousands of tcp connections without sending data each holding a goroutine+file descriptor forever
+
 			reader := bufio.NewReader(conn)
-			//fix:add a read deadline immediately after the reader is created
-			conn.SetReadDeadline(time.Now().Add(10 * time.Second))
+
+			if err := conn.SetReadDeadline(time.Now().Add(headerReadDeadline)); err != nil {
+				fmt.Fprintf(log, "failed to set header read deadline for %s: %v\n", conn.RemoteAddr().String(), err)
+				return
+			}
 			kind, err := proto.ReadHeader(reader)
-			//after successful read clear the deadline
-			conn.SetReadDeadline(time.Time{})
 			if err != nil {
 				if errors.Is(err, io.EOF) {
 					return
@@ -261,16 +272,26 @@ func Run(ctx context.Context, log io.Writer, cfg Config) error {
 				fmt.Fprintf(log, "session error from %s: %v\n", conn.RemoteAddr().String(), err)
 				return
 			}
+
+			if err := conn.SetReadDeadline(time.Time{}); err != nil {
+				fmt.Fprintf(log, "failed to clear header deadline for %s: %v\n", conn.RemoteAddr().String(), err)
+				return
+			}
+
 			liveCfg := runtimeConfig(cfg)
 			relayGovernor.Update(liveCfg.RelayMode, liveCfg.RelayResourcePercent)
 
 			switch kind {
 			case proto.KindFileTransfer:
+
+				_ = conn.SetDeadline(time.Now().Add(handshakeDeadline))
 				secureConn, err := secure.Server(&bufferedConn{Conn: conn, reader: reader}, proto.KindFileTransfer, cfg.Identity)
 				if err != nil {
 					fmt.Fprintf(log, "secure receive error from %s: %v\n", conn.RemoteAddr().String(), err)
 					return
 				}
+
+				_ = conn.SetDeadline(time.Now().Add(idleSessionDeadline))
 				res, err := transfer.ReceiveFileWithPolicy(secureConn, liveCfg.ReceiveDir, fileReceivePolicy(liveCfg))
 				if err != nil {
 					fmt.Fprintf(log, "receive error from %s: %v\n", conn.RemoteAddr().String(), err)
@@ -282,17 +303,23 @@ func Run(ctx context.Context, log io.Writer, cfg Config) error {
 				}
 				fmt.Fprintf(log, "received %q (%d bytes) from node %q into %s\n", res.FileName, res.BytesReceived, res.SenderNode, absPath)
 			case proto.KindDiscoveryReq:
+
+				_ = conn.SetDeadline(time.Now().Add(discoveryDeadline))
 				if err := cfg.Registry.HandleConn(&bufferedConn{Conn: conn, reader: reader}); err != nil {
 					fmt.Fprintf(log, "discovery error from %s: %v\n", conn.RemoteAddr().String(), err)
 					return
 				}
 				fmt.Fprintf(log, "processed discovery request from %s\n", conn.RemoteAddr().String())
 			case proto.KindDHT:
+
+				_ = conn.SetReadDeadline(time.Now().Add(dhtPayloadDeadline))
 				payload, err := proto.ReadLengthPrefixed(reader, 1024*1024)
 				if err != nil {
 					fmt.Fprintf(log, "dht read error from %s: %v\n", conn.RemoteAddr().String(), err)
 					return
 				}
+
+				_ = conn.SetDeadline(time.Now().Add(discoveryDeadline))
 				var dr proto.DHTRequest
 				if err := json.Unmarshal(payload, &dr); err != nil {
 					fmt.Fprintf(log, "dht decode error from %s: %v\n", conn.RemoteAddr().String(), err)
@@ -310,11 +337,15 @@ func Run(ctx context.Context, log io.Writer, cfg Config) error {
 					return
 				}
 				defer release()
+
+				_ = conn.SetDeadline(time.Now().Add(relayHandshakeDeadline))
 				secureConn, err := secure.Server(&bufferedConn{Conn: conn, reader: reader}, proto.KindExtend, cfg.Identity)
 				if err != nil {
 					fmt.Fprintf(log, "extend secure handshake error from %s: %v\n", conn.RemoteAddr().String(), err)
 					return
 				}
+
+				_ = conn.SetDeadline(time.Now().Add(idleSessionDeadline))
 				if err := onion.HandleExtend(ctx, secureConn, cfg.Identity); err != nil {
 					fmt.Fprintf(log, "extend error from %s: %v\n", conn.RemoteAddr().String(), err)
 				}
@@ -325,6 +356,8 @@ func Run(ctx context.Context, log io.Writer, cfg Config) error {
 					return
 				}
 				defer release()
+
+				_ = conn.SetDeadline(time.Now().Add(relayHandshakeDeadline))
 				liveServices := liveCfg.Services
 				if err := hidden.HandleConn(ctx, &bufferedConn{Conn: conn, reader: reader}, hidden.HandlerConfig{
 					Identity:      cfg.Identity,
@@ -337,6 +370,8 @@ func Run(ctx context.Context, log io.Writer, cfg Config) error {
 					fmt.Fprintf(log, "hidden service error from %s: %v\n", conn.RemoteAddr().String(), err)
 				}
 			case proto.KindServiceConn:
+
+				_ = conn.SetDeadline(time.Now().Add(serviceProxyDeadline))
 				if err := serviceproxy.HandleInbound(&bufferedConn{Conn: conn, reader: reader}, cfg.Identity, runtimeServices(cfg)); err != nil {
 					fmt.Fprintf(log, "service proxy error from %s: %v\n", conn.RemoteAddr().String(), err)
 				}
@@ -352,6 +387,13 @@ func endpointPublishMode(hidden bool) string {
 		return "hidden"
 	}
 	return "published"
+}
+
+func effectiveMaxConcurrentConns(configured int) int {
+	if configured > 0 {
+		return configured
+	}
+	return defaultMaxConcurrentConns
 }
 
 func shouldRunPeerSyncTasks(cfg Config) bool {
@@ -1035,6 +1077,7 @@ func runtimeConfig(base Config) Config {
 	live.HideEndpoint = cfgFile.Node.HideEndpoint
 	live.RelayMode = cfgFile.Node.RelayMode
 	live.RelayResourcePercent = cfgFile.Node.RelayResourcePercent
+	live.MaxConcurrentConns = cfgFile.Node.MaxConcurrentConns
 	live.PeerAddrs = config.ConfiguredPeerAddresses(cfgFile)
 	live.FileReceiveMode = cfgFile.Node.FileReceiveMode
 	live.AllowedFileSenders = append([]string(nil), cfgFile.Node.AllowedFileSenders...)


### PR DESCRIPTION
noticed the accept loop in node.Run() could be abused pretty easily
connections had no read deadline before proto.ReadHeader() so a peer could just connect and sit there forever holding resources
also there was no limit on concurrent connections, so every incoming connection would spin up a new goroutine which could get ugly under a flood
added a 10s read deadline before the handshake and cleared it after a successful header read
also added a simple semaphore cap (1024 connections) so extra connections get dropped instead of endlessly spawning goroutine
